### PR TITLE
Modify README.md to add prerequisite(openjdk)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Example:
 
 ![Example default style](https://krisztianb.github.io/typedoc-umlclass/docs/human-default-layout.png)
 
+## Prerequisite
+
+You will need [openjdk](https://openjdk.java.net/).
+
 ## Installation
 
 The plugin can then be installed using [npm](https://www.npmjs.com/package/typedoc-umlclass):


### PR DESCRIPTION
You need `java` to use this plug-in. 
If there is no java, below error occurs.

```
Loaded plugin typedoc-umlclass

Using TypeScript 3.9.7 from /home/circleci/project2/node_modules/typescript/lib
Rendering [=---------------------------------------] 3%events.js:174
      throw er; // Unhandled 'error' event
      ^

Error: write EPIPE
    at afterWriteDispatched (internal/stream_base_commons.js:78:25)
    at writeGeneric (internal/stream_base_commons.js:73:3)
    at Socket._writeGeneric (net.js:714:5)
    at Socket._write (net.js:726:8)
    at doWrite (_stream_writable.js:415:12)
    at writeOrBuffer (_stream_writable.js:399:5)
    at Socket.Writable.write (_stream_writable.js:299:11)
    at PlantUmlDiagramGenerator.generate (/home/circleci/project2/node_modules/typedoc-umlclass/dist/plantuml/plantuml_diagram_generator.js:38:25)
    at Plugin.processPage (/home/circleci/project2/node_modules/typedoc-umlclass/dist/plugin.js:260:43)
    at Plugin.onRendererEndPage (/home/circleci/project2/node_modules/typedoc-umlclass/dist/plugin.js:206:22)
Emitted 'error' event at:
    at errorOrDestroy (internal/streams/destroy.js:107:12)
    at onwriteError (_stream_writable.js:430:5)
    at onwrite (_stream_writable.js:461:5)
    at _destroy (internal/streams/destroy.js:49:7)
    at Socket._destroy (net.js:614:3)
    at Socket.destroy (internal/streams/destroy.js:37:8)
    at afterWriteDispatched (internal/stream_base_commons.js:78:17)
    at writeGeneric (internal/stream_base_commons.js:73:3)
    at Socket._writeGeneric (net.js:714:5)
    at Socket._writeGeneric (net.js:714:5)
    at Socket._write (net.js:726:8)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @homeiot/partnersdk@2.0.2 html-docs-gen: `rm -rf html-docs && typedoc --includeDeclarations --excludeExternals --plugin typedoc-umlclass --mode file --out html-docs s
rc`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the @homeiot/partnersdk@2.0.2 html-docs-gen script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/circleci/.npm/_logs/2020-11-13T07_34_34_859Z-debug.log

```